### PR TITLE
feat: 도시 상세 페이지 및 코워킹 스팟 정보 추가

### DIFF
--- a/app/cities/[id]/page.tsx
+++ b/app/cities/[id]/page.tsx
@@ -1,0 +1,219 @@
+import { notFound } from 'next/navigation'
+import Image from 'next/image'
+import Link from 'next/link'
+import { getCityById, getAllCityIds } from '@/lib/data/cities'
+import { getUnsplashImage } from '@/lib/unsplash'
+import { Badge } from '@/components/ui/badge'
+import { LikeDislikeButtons } from '@/components/city/LikeDislikeButtons'
+import { BUDGETS, REGIONS } from '@/lib/data/constants'
+import { ArrowLeft, Wifi, MapPin, Home, Zap, Train, Coffee, Monitor } from 'lucide-react'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export async function generateStaticParams() {
+  return getAllCityIds().map(id => ({ id }))
+}
+
+export default async function CityDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const city = getCityById(id)
+
+  if (!city) {
+    notFound()
+  }
+
+  const imageUrl = getUnsplashImage(city.image)
+
+  const getBudgetLabel = (value: string) =>
+    BUDGETS.find(b => b.value === value)?.label || value
+
+  const getRegionLabel = (value: string) =>
+    REGIONS.find(r => r.name === value)?.label || value
+
+  const wifiColorMap = {
+    '빠름': 'text-green-600 bg-green-50 border-green-200',
+    '보통': 'text-yellow-600 bg-yellow-50 border-yellow-200',
+    '느림': 'text-red-600 bg-red-50 border-red-200',
+  }
+
+  return (
+    <main className="min-h-screen bg-cream">
+      {/* Hero Image */}
+      <div className="relative w-full h-[40vh] bg-sand">
+        <Image
+          src={imageUrl}
+          alt={city.name}
+          fill
+          className="object-cover"
+          sizes="100vw"
+          priority
+        />
+        <div className="absolute inset-0 bg-bark/40" />
+        {/* Back Button */}
+        <div className="absolute top-4 left-4">
+          <Link
+            href="/"
+            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-cream/90 text-earth font-medium hover:bg-cream transition-all text-sm"
+          >
+            <ArrowLeft size={16} />
+            목록으로
+          </Link>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+
+        {/* Title & Score */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-earth">
+              {city.name}
+              <span className="ml-3 text-lg font-normal text-moss">{city.nameEn}</span>
+            </h1>
+            <div className="flex items-center gap-2 mt-2">
+              <MapPin size={14} className="text-moss" />
+              <span className="text-moss text-sm">{getRegionLabel(city.region)}</span>
+            </div>
+          </div>
+          <div className="flex flex-col items-center bg-forest/10 border-2 border-forest/20 rounded-2xl px-5 py-3">
+            <span className="text-xs text-moss">종합점수</span>
+            <span className="text-3xl font-bold text-forest">{city.totalScore}</span>
+            <span className="text-xs text-moss">/ 100</span>
+          </div>
+        </div>
+
+        {/* Tags & Badges */}
+        <div className="flex flex-wrap gap-2">
+          {city.tags.map(tag => (
+            <Badge key={tag} variant="secondary" className="text-sm bg-sand/60 text-earth border border-sand rounded-full px-3 py-1">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+
+        {/* Info Badges */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div className="bg-white border-2 border-sand rounded-2xl p-3 text-center">
+            <div className="text-xs text-moss font-medium mb-1">예산</div>
+            <div className="text-sm font-semibold text-earth">{getBudgetLabel(city.budget)}</div>
+          </div>
+          <div className="bg-white border-2 border-sand rounded-2xl p-3 text-center">
+            <div className="text-xs text-moss font-medium mb-1">최고 계절</div>
+            <div className="text-sm font-semibold text-earth">{city.bestSeason.join(' · ')}</div>
+          </div>
+          <div className="bg-white border-2 border-sand rounded-2xl p-3 text-center col-span-2 md:col-span-2">
+            <div className="text-xs text-moss font-medium mb-1">작업 환경</div>
+            <div className="text-sm font-semibold text-earth">{city.environment.join(' · ')}</div>
+          </div>
+        </div>
+
+        {/* Description */}
+        {city.detail && (
+          <>
+            <div className="bg-white border-2 border-sand rounded-2xl p-5">
+              <h2 className="text-lg font-semibold text-earth mb-3">도시 소개</h2>
+              <p className="text-earth/80 leading-relaxed">{city.detail.description}</p>
+            </div>
+
+            {/* Practical Info */}
+            <div className="bg-white border-2 border-sand rounded-2xl p-5">
+              <h2 className="text-lg font-semibold text-earth mb-4">실용 정보</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="flex items-start gap-3">
+                  <div className="p-2 bg-sage/20 rounded-xl">
+                    <Home size={18} className="text-forest" />
+                  </div>
+                  <div>
+                    <div className="text-xs text-moss font-medium">월세 (원룸 기준)</div>
+                    <div className="text-sm font-semibold text-earth mt-0.5">{city.detail.monthlyRent}</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <div className="p-2 bg-sage/20 rounded-xl">
+                    <Zap size={18} className="text-forest" />
+                  </div>
+                  <div>
+                    <div className="text-xs text-moss font-medium">인터넷 속도</div>
+                    <div className="text-sm font-semibold text-earth mt-0.5">{city.detail.internetSpeed}</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <div className="p-2 bg-sage/20 rounded-xl">
+                    <Train size={18} className="text-forest" />
+                  </div>
+                  <div>
+                    <div className="text-xs text-moss font-medium">교통</div>
+                    <div className="text-sm font-semibold text-earth mt-0.5">{city.detail.transportation}</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Coworking Spots */}
+            <div>
+              <h2 className="text-lg font-semibold text-earth mb-4">추천 작업 공간</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {city.detail.coworkingSpots.map((spot, index) => (
+                  <div
+                    key={index}
+                    className="bg-white border-2 border-sand rounded-2xl p-4 space-y-3"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        {spot.type === '카페' ? (
+                          <Coffee size={16} className="text-terracotta flex-shrink-0" />
+                        ) : (
+                          <Monitor size={16} className="text-forest flex-shrink-0" />
+                        )}
+                        <h3 className="font-semibold text-earth text-sm">{spot.name}</h3>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={`text-xs rounded-full border flex-shrink-0 ${
+                          spot.type === '카페'
+                            ? 'text-terracotta border-terracotta/30 bg-terracotta/10'
+                            : 'text-forest border-forest/30 bg-forest/10'
+                        }`}
+                      >
+                        {spot.type}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-earth/70">{spot.description}</p>
+                    <div className="flex items-center gap-3 text-xs">
+                      <span className={`flex items-center gap-1 px-2 py-1 rounded-lg border font-medium ${wifiColorMap[spot.wifi]}`}>
+                        <Wifi size={11} />
+                        WiFi {spot.wifi}
+                      </span>
+                      {spot.hasPlug && (
+                        <span className="flex items-center gap-1 px-2 py-1 rounded-lg border text-blue-600 bg-blue-50 border-blue-200 font-medium">
+                          <Zap size={11} />
+                          콘센트
+                        </span>
+                      )}
+                      {spot.pricePerDay !== null ? (
+                        <span className="text-moss font-medium">
+                          {spot.pricePerDay.toLocaleString()}원/일
+                        </span>
+                      ) : (
+                        <span className="text-moss font-medium">음료 주문</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Like/Dislike */}
+        <div className="flex items-center gap-4 py-4 border-t-2 border-sand">
+          <span className="text-sm text-moss font-medium">이 도시가 마음에 드셨나요?</span>
+          <LikeDislikeButtons initialLikes={city.likes} initialDislikes={city.dislikes} />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/components/city/CityCard.tsx
+++ b/components/city/CityCard.tsx
@@ -7,6 +7,7 @@ import { ThumbsUp, ThumbsDown } from 'lucide-react'
 import { getUnsplashImage } from '@/lib/unsplash'
 import Image from 'next/image'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { BUDGETS, REGIONS, ENVIRONMENTS, SEASONS } from '@/lib/data/constants'
 
 interface CityCardProps {
@@ -14,6 +15,7 @@ interface CityCardProps {
 }
 
 export function CityCard({ city }: CityCardProps) {
+  const router = useRouter()
   const [isLiked, setIsLiked] = useState(false)
   const [isDisliked, setIsDisliked] = useState(false)
   const [currentLikes, setCurrentLikes] = useState(city.likes)
@@ -21,16 +23,14 @@ export function CityCard({ city }: CityCardProps) {
 
   const imageUrl = getUnsplashImage(city.image)
 
-  const handleLike = () => {
+  const handleLike = (e: React.MouseEvent) => {
+    e.stopPropagation()
     if (isLiked) {
-      // 좋아요 취소
       setIsLiked(false)
       setCurrentLikes(currentLikes - 1)
     } else {
-      // 좋아요 추가
       setIsLiked(true)
       setCurrentLikes(currentLikes + 1)
-      // 싫어요가 활성화되어 있다면 취소
       if (isDisliked) {
         setIsDisliked(false)
         setCurrentDislikes(currentDislikes - 1)
@@ -38,16 +38,14 @@ export function CityCard({ city }: CityCardProps) {
     }
   }
 
-  const handleDislike = () => {
+  const handleDislike = (e: React.MouseEvent) => {
+    e.stopPropagation()
     if (isDisliked) {
-      // 싫어요 취소
       setIsDisliked(false)
       setCurrentDislikes(currentDislikes - 1)
     } else {
-      // 싫어요 추가
       setIsDisliked(true)
       setCurrentDislikes(currentDislikes + 1)
-      // 좋아요가 활성화되어 있다면 취소
       if (isLiked) {
         setIsLiked(false)
         setCurrentLikes(currentLikes - 1)
@@ -69,7 +67,10 @@ export function CityCard({ city }: CityCardProps) {
     SEASONS.find(s => s.value === value)?.label || value
 
   return (
-    <Card className="overflow-hidden hover:shadow-nature-lg transition-all duration-300 hover:scale-[1.02] h-full rounded-3xl border-2 border-sand bg-cream">
+    <Card
+      onClick={() => router.push(`/cities/${city.id}`)}
+      className="overflow-hidden hover:shadow-nature-lg transition-all duration-300 hover:scale-[1.02] h-full rounded-3xl border-2 border-sand bg-cream cursor-pointer"
+    >
       {/* Image Container */}
       <div className="relative w-full aspect-video bg-sand overflow-hidden rounded-t-3xl">
         <Image

--- a/components/city/LikeDislikeButtons.tsx
+++ b/components/city/LikeDislikeButtons.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { ThumbsUp, ThumbsDown } from 'lucide-react'
+import { useState } from 'react'
+
+interface LikeDislikeButtonsProps {
+  initialLikes: number
+  initialDislikes: number
+}
+
+export function LikeDislikeButtons({ initialLikes, initialDislikes }: LikeDislikeButtonsProps) {
+  const [isLiked, setIsLiked] = useState(false)
+  const [isDisliked, setIsDisliked] = useState(false)
+  const [currentLikes, setCurrentLikes] = useState(initialLikes)
+  const [currentDislikes, setCurrentDislikes] = useState(initialDislikes)
+
+  const handleLike = () => {
+    if (isLiked) {
+      setIsLiked(false)
+      setCurrentLikes(currentLikes - 1)
+    } else {
+      setIsLiked(true)
+      setCurrentLikes(currentLikes + 1)
+      if (isDisliked) {
+        setIsDisliked(false)
+        setCurrentDislikes(currentDislikes - 1)
+      }
+    }
+  }
+
+  const handleDislike = () => {
+    if (isDisliked) {
+      setIsDisliked(false)
+      setCurrentDislikes(currentDislikes - 1)
+    } else {
+      setIsDisliked(true)
+      setCurrentDislikes(currentDislikes + 1)
+      if (isLiked) {
+        setIsLiked(false)
+        setCurrentLikes(currentLikes - 1)
+      }
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        onClick={handleLike}
+        className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all font-medium ${
+          isLiked
+            ? 'bg-blue-100 text-blue-600 border-2 border-blue-300'
+            : 'bg-sage/30 text-earth hover:bg-sage/50 border-2 border-sand'
+        }`}
+        aria-label="좋아요"
+      >
+        <ThumbsUp size={18} className={isLiked ? 'fill-blue-600' : ''} />
+        <span>{currentLikes}</span>
+      </button>
+
+      <button
+        onClick={handleDislike}
+        className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all font-medium ${
+          isDisliked
+            ? 'bg-red-100 text-red-600 border-2 border-red-300'
+            : 'bg-sage/30 text-earth hover:bg-sage/50 border-2 border-sand'
+        }`}
+        aria-label="싫어요"
+      >
+        <ThumbsDown size={18} className={isDisliked ? 'fill-red-600' : ''} />
+        <span>{currentDislikes}</span>
+      </button>
+    </div>
+  )
+}

--- a/lib/data/cities.ts
+++ b/lib/data/cities.ts
@@ -14,6 +14,17 @@ export const cities: City[] = [
     dislikes: 12,
     tags: ['해변가', '카페천국', '관광도시'],
     budget: 'range100to200',
+    detail: {
+      description: '제주시는 제주도의 행정 중심지로, 아름다운 해변과 한라산을 배경으로 한 자연환경 속에서 일하기 최적의 도시입니다. 제주 공항과 가까워 접근성이 좋으며, 감성 카페가 넘쳐나 카페 작업을 즐기는 디지털 노마드에게 인기가 높습니다.',
+      monthlyRent: '60~90만원',
+      internetSpeed: '500Mbps 이상',
+      transportation: '렌터카/카카오 바이크 권장, 공항버스 운행',
+      coworkingSpots: [
+        { name: '카페 제주해녀', type: '카페', wifi: '빠름', hasPlug: true, pricePerDay: null, description: '해변 뷰 감성 카페, 24시간 운영' },
+        { name: 'Jeju Work Hub', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 25000, description: '1일권 25,000원, 회의실 포함' },
+        { name: '스페이스 돌하르방', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 20000, description: '월정 할인 제공, 커뮤니티 이벤트' },
+      ],
+    },
   },
   {
     id: 'seogwipo',
@@ -28,6 +39,16 @@ export const cities: City[] = [
     dislikes: 15,
     tags: ['조용한', '해변가', '예술'],
     budget: 'range100to200',
+    detail: {
+      description: '서귀포는 제주도 남쪽의 조용한 소도시로, 천지연 폭포와 정방 폭포 등 자연경관이 수려합니다. 관광객이 상대적으로 적어 집중하기 좋은 환경이며, 제주시보다 물가가 저렴한 편입니다. 예술가 커뮤니티가 활성화되어 창의적인 분위기를 즐길 수 있습니다.',
+      monthlyRent: '50~75만원',
+      internetSpeed: '100Mbps 이상',
+      transportation: '렌터카 필수, 시내버스 운행',
+      coworkingSpots: [
+        { name: '카페 이중섭', type: '카페', wifi: '보통', hasPlug: true, pricePerDay: null, description: '이중섭 거리 인근, 예술적 분위기' },
+        { name: '서귀포 소셜 허브', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 18000, description: '월 회원권 할인, 조용한 작업 환경' },
+      ],
+    },
   },
   {
     id: 'busan',
@@ -42,6 +63,18 @@ export const cities: City[] = [
     dislikes: 28,
     tags: ['대도시', '카페천국', '야경'],
     budget: 'over200',
+    detail: {
+      description: '부산은 대한민국 제2의 도시로, 해운대 해변부터 감천 문화마을까지 다양한 매력을 가진 도시입니다. 서울과 달리 여유로운 라이프스타일을 즐기면서도 대도시의 인프라를 누릴 수 있어 많은 디지털 노마드가 선택하는 곳입니다. 코워킹 공간이 다양하게 갖춰져 있습니다.',
+      monthlyRent: '70~120만원',
+      internetSpeed: '1Gbps',
+      transportation: '지하철 2호선 중심, 버스 노선 풍부',
+      coworkingSpots: [
+        { name: '해운대 워크샵', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 30000, description: '해운대 뷰, 프리미엄 코워킹 공간' },
+        { name: '카페 센텀', type: '카페', wifi: '빠름', hasPlug: true, pricePerDay: null, description: '센텀시티 인근, 24시간 운영' },
+        { name: '부산 창업 허브', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 22000, description: '스타트업 커뮤니티 활성, 네트워킹 이벤트' },
+        { name: '광안리 작업실', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 20000, description: '광안대교 야경 감상 가능' },
+      ],
+    },
   },
   {
     id: 'gangneung',
@@ -56,6 +89,16 @@ export const cities: City[] = [
     dislikes: 8,
     tags: ['해변가', '경제적', '조용한'],
     budget: 'under100',
+    detail: {
+      description: '강릉은 동해 해변과 커피 문화로 유명한 강원도 대표 도시입니다. 안목해변 카페 거리는 전국적으로 유명하며, 평창동계올림픽 이후 인프라가 크게 개선되었습니다. 물가가 저렴하고 공기가 맑아 장기 체류 노마드에게 인기입니다.',
+      monthlyRent: '40~65만원',
+      internetSpeed: '500Mbps',
+      transportation: '렌터카 또는 자전거 권장, KTX 강릉역 이용 가능',
+      coworkingSpots: [
+        { name: '안목 카페 테라스', type: '카페', wifi: '빠름', hasPlug: true, pricePerDay: null, description: '바다 뷰 테라스, 강릉커피의 명소' },
+        { name: '강릉 노마드 베이스', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 15000, description: '장기 노마드 커뮤니티 운영, 저렴한 월정액' },
+      ],
+    },
   },
   {
     id: 'jeonju',
@@ -70,6 +113,17 @@ export const cities: City[] = [
     dislikes: 11,
     tags: ['전통', '음식', '문화'],
     budget: 'range100to200',
+    detail: {
+      description: '전주는 한옥마을과 비빔밥으로 유명한 전통문화 도시입니다. 한국의 역사와 문화를 느끼며 일할 수 있는 독특한 경험을 제공합니다. 감성적인 한옥 카페와 현대적인 카페가 조화를 이루고, 음식이 맛있어 일상의 만족도가 높습니다.',
+      monthlyRent: '45~70만원',
+      internetSpeed: '500Mbps',
+      transportation: '시내버스 중심, 도보 이동 가능한 컴팩트한 도심',
+      coworkingSpots: [
+        { name: '한옥마을 작업실', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 18000, description: '한옥 분위기의 독특한 코워킹 공간' },
+        { name: '카페 경기전', type: '카페', wifi: '보통', hasPlug: true, pricePerDay: null, description: '경기전 인근 감성 카페, 한국 전통 음료 제공' },
+        { name: '전주 크리에이티브 허브', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 20000, description: '청년 창업가 네트워크, 스튜디오 공간 보유' },
+      ],
+    },
   },
   {
     id: 'gyeongju',
@@ -84,6 +138,16 @@ export const cities: City[] = [
     dislikes: 7,
     tags: ['역사', '조용한', '경제적'],
     budget: 'under100',
+    detail: {
+      description: '경주는 신라 천년의 고도로, 유네스코 세계문화유산이 가득한 역사 도시입니다. 도심 자체가 거대한 박물관이라 불리며, 곳곳에 유적지와 자연경관이 어우러져 있습니다. 조용하고 물가가 저렴해 집중 작업에 최적화된 환경을 제공합니다.',
+      monthlyRent: '35~55만원',
+      internetSpeed: '100Mbps',
+      transportation: '자전거 문화 발달, 렌터카 이용 권장',
+      coworkingSpots: [
+        { name: '황리단길 카페', type: '카페', wifi: '보통', hasPlug: false, pricePerDay: null, description: '경주 핫플 황리단길, 감성적 분위기' },
+        { name: '경주 스터디 카페', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 12000, description: '24시간 운영, 저렴한 이용료' },
+      ],
+    },
   },
   {
     id: 'sokcho',
@@ -98,6 +162,16 @@ export const cities: City[] = [
     dislikes: 9,
     tags: ['산', '해변가', '자연'],
     budget: 'under100',
+    detail: {
+      description: '속초는 설악산과 동해 바다가 만나는 강원도의 보석 같은 도시입니다. 청초호와 영랑호 등 아름다운 호수도 있어 다양한 자연환경을 즐길 수 있습니다. 최근 케이블카와 워터파크 등 개발로 관광 인프라가 향상되었으나, 아직 조용한 편입니다.',
+      monthlyRent: '38~60만원',
+      internetSpeed: '500Mbps',
+      transportation: '렌터카 권장, 시내버스 운행, KTX 강릉역에서 버스 이용',
+      coworkingSpots: [
+        { name: '청초호 카페', type: '카페', wifi: '빠름', hasPlug: true, pricePerDay: null, description: '호수 전망, 새벽부터 심야까지 운영' },
+        { name: '속초 리모트 스테이션', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 16000, description: '숙소 겸 코워킹 공간, 커뮤니티 활성' },
+      ],
+    },
   },
   {
     id: 'yeosu',
@@ -112,6 +186,17 @@ export const cities: City[] = [
     dislikes: 10,
     tags: ['야경', '해변가', '관광'],
     budget: 'range100to200',
+    detail: {
+      description: '여수는 "밤바다"로 유명한 전라남도의 해양 도시입니다. 이순신 광장과 케이블카, 디오션 워터파크 등 풍부한 관광 자원을 보유하고 있습니다. 해산물이 신선하고 저렴하며, 해안 산책로를 따라 카페들이 늘어서 있어 여유로운 노마드 생활을 즐길 수 있습니다.',
+      monthlyRent: '45~70만원',
+      internetSpeed: '500Mbps',
+      transportation: '시내버스 운행, KTX 여수엑스포역 이용 가능',
+      coworkingSpots: [
+        { name: '돌산도 뷰 카페', type: '카페', wifi: '빠름', hasPlug: true, pricePerDay: null, description: '돌산도 전망, 야경 명소' },
+        { name: '여수 워크스페이스', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 18000, description: '시내 중심가, 회의실 완비' },
+        { name: '이순신 광장 카페거리', type: '카페', wifi: '보통', hasPlug: false, pricePerDay: null, description: '광장 인근 감성 카페 밀집 지역' },
+      ],
+    },
   },
   {
     id: 'seoul',
@@ -126,6 +211,18 @@ export const cities: City[] = [
     dislikes: 45,
     tags: ['대도시', '편의점', '사람들'],
     budget: 'over200',
+    detail: {
+      description: '서울은 세계적인 대도시로, IT 인프라와 스타트업 생태계가 최고 수준입니다. 강남, 성수, 홍대 등 지역마다 독특한 분위기를 가지고 있으며, 24시간 활동 가능한 도시입니다. 빠른 인터넷, 풍부한 코워킹 공간, 다양한 네트워킹 기회가 있어 비즈니스 디지털 노마드에게 최적입니다.',
+      monthlyRent: '80~150만원',
+      internetSpeed: '1Gbps',
+      transportation: '지하철 9호선 포함 22개 노선, 도보+대중교통으로 충분',
+      coworkingSpots: [
+        { name: 'FastFive 강남', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 35000, description: '프리미엄 코워킹, 강남 핵심 위치' },
+        { name: '카페 성수 언더스탠드에비뉴', type: '카페', wifi: '빠름', hasPlug: true, pricePerDay: null, description: '성수 힙스터 카페 특구' },
+        { name: '스파크플러스 홍대', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 28000, description: '홍대 창업 커뮤니티, 다양한 이벤트' },
+        { name: '카카오 공유 오피스', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 40000, description: '판교 IT 클러스터, 테크 네트워킹' },
+      ],
+    },
   },
   {
     id: 'incheon',
@@ -140,5 +237,24 @@ export const cities: City[] = [
     dislikes: 13,
     tags: ['공항근처', '교통', '국제도시'],
     budget: 'range100to200',
+    detail: {
+      description: '인천은 국제공항을 보유한 한국의 관문 도시입니다. 인천국제공항과 가까워 잦은 해외 출장이 필요한 디지털 노마드에게 특히 유리합니다. 송도 신도시는 체계적으로 개발된 스마트시티로 쾌적한 환경을 제공하며, 차이나타운, 개항장 등 역사적 명소도 있습니다.',
+      monthlyRent: '50~80만원',
+      internetSpeed: '1Gbps',
+      transportation: '공항철도, 지하철 1·2호선, 공항버스 등 교통 편리',
+      coworkingSpots: [
+        { name: '송도 코워킹 스퀘어', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 25000, description: '송도 신도시 중심, 현대적 시설' },
+        { name: '인천공항 비즈니스 라운지', type: '코워킹', wifi: '빠름', hasPlug: true, pricePerDay: 30000, description: '공항 내 작업 공간, 출발 전 이용 가능' },
+        { name: '개항장 카페 거리', type: '카페', wifi: '보통', hasPlug: false, pricePerDay: null, description: '근대 건축물 속 감성 카페, 역사 지구' },
+      ],
+    },
   },
 ]
+
+export function getCityById(id: string): City | undefined {
+  return cities.find(city => city.id === id)
+}
+
+export function getAllCityIds(): string[] {
+  return cities.map(city => city.id)
+}

--- a/types/city.ts
+++ b/types/city.ts
@@ -6,6 +6,23 @@ export type Region = '수도권' | '경상도' | '전라도' | '강원도' | '�
 
 export type BudgetRange = 'under100' | 'range100to200' | 'over200'
 
+export interface CoworkingSpot {
+  name: string
+  type: '카페' | '코워킹'
+  wifi: '빠름' | '보통' | '느림'
+  hasPlug: boolean
+  pricePerDay: number | null // null = 카페 (별도 요금 없음)
+  description: string
+}
+
+export interface CityDetail {
+  description: string
+  monthlyRent: string       // 예: "50~80만원"
+  internetSpeed: string     // 예: "100Mbps 이상"
+  transportation: string    // 예: "버스 중심, 렌터카 권장"
+  coworkingSpots: CoworkingSpot[]
+}
+
 export interface City {
   id: string
   name: string
@@ -19,4 +36,5 @@ export interface City {
   dislikes: number
   tags: string[]
   budget: BudgetRange
+  detail?: CityDetail
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,2 +1,2 @@
-export type { City, Region, BudgetRange, Environment, Season } from './city'
+export type { City, Region, BudgetRange, Environment, Season, CoworkingSpot, CityDetail } from './city'
 export type { Review } from './review'


### PR DESCRIPTION
## Summary

- `types/city.ts`에 `CityDetail`, `CoworkingSpot` 인터페이스 추가
- 전국 10개 도시에 상세 정보(도시 소개, 월세, 인터넷 속도, 교통, 코워킹 스팟) 데이터 추가
- `app/cities/[id]/page.tsx` 신규 생성 — 히어로 이미지, 실용 정보, 코워킹 스팟 섹션 포함
- `LikeDislikeButtons` 컴포넌트 분리 — 상세 페이지에서 재사용 가능하도록 추출
- `CityCard` 클릭 시 상세 페이지로 이동, 좋아요/싫어요 버튼에 `stopPropagation` 적용
- `getCityById()`, `getAllCityIds()` 유틸리티 함수 추가

## Test plan

- [ ] 메인 페이지 도시 카드 클릭 → `/cities/{id}` 로 정상 이동 확인
- [ ] 상세 페이지 히어로 이미지, 도시 소개, 실용 정보 섹션 렌더링 확인
- [ ] 코워킹 스팟 카드 — WiFi 속도, 콘센트 여부, 가격 정보 표시 확인
- [ ] 좋아요/싫어요 버튼: 카드 클릭과 독립적으로 동작 확인 (stopPropagation)
- [ ] 상세 페이지 좋아요/싫어요 버튼 상호 배타적 토글 확인
- [ ] "목록으로" 버튼으로 메인 페이지 복귀 확인
- [ ] 존재하지 않는 도시 ID 접근 시 404 페이지 표시 확인
- [ ] 모바일/태블릿/데스크탑 반응형 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)