### PR TITLE
fix: 필터 너비 확장, 계절 워딩 수정, Footer 미구현 링크 제거

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -3,89 +3,22 @@ import { Separator } from '@/components/ui/separator'
 export function Footer() {
   const currentYear = new Date().getFullYear()
 
-  const footerSections = [
-    {
-      title: '서비스',
-      links: [
-        { label: '도시 검색', href: '#' },
-        { label: '리뷰 보기', href: '#' },
-        { label: '통계', href: '#' },
-      ],
-    },
-    {
-      title: '커뮤니티',
-      links: [
-        { label: '블로그', href: '#' },
-        { label: '포럼', href: '#' },
-        { label: '이벤트', href: '#' },
-      ],
-    },
-    {
-      title: '고객지원',
-      links: [
-        { label: '자주 묻는 질문', href: '#' },
-        { label: '문의하기', href: '#' },
-        { label: '개인정보처리방침', href: '#' },
-      ],
-    },
-  ]
-
   return (
     <footer className="bg-earth text-sage mt-20">
       <div className="max-w-7xl mx-auto px-4 py-12">
-        {/* Footer Content Grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-8">
-          {/* Brand */}
-          <div className="col-span-2 md:col-span-1">
-            <div className="flex items-center gap-2 mb-4">
-              <span className="text-3xl">🇰🇷</span>
-              <span className="text-xl font-bold text-cream">K.NOMAD</span>
-            </div>
-            <p className="text-sm text-sage/80">한국에서 노마드 생활하기 좋은 도시를 찾아보세요.</p>
+        {/* Brand */}
+        <div>
+          <div className="flex items-center gap-2 mb-4">
+            <span className="text-3xl">🇰🇷</span>
+            <span className="text-xl font-bold text-cream">K.NOMAD</span>
           </div>
-
-          {/* Footer Sections */}
-          {footerSections.map((section) => (
-            <div key={section.title}>
-              <h4 className="font-semibold text-cream mb-4">{section.title}</h4>
-              <ul className="space-y-2">
-                {section.links.map((link) => (
-                  <li key={link.label}>
-                    <a href={link.href} className="text-sm hover:text-cream transition-colors">
-                      {link.label}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+          <p className="text-sm text-sage/80">한국에서 노마드 생활하기 좋은 도시를 찾아보세요.</p>
         </div>
 
-        <Separator className="bg-moss/30" />
+        <Separator className="bg-moss/30 my-8" />
 
-        {/* Bottom Section */}
-        <div className="mt-8 space-y-6">
-          {/* Social Links */}
-          <div className="flex gap-6">
-            <a href="#" className="text-sage/80 hover:text-cream transition-colors">
-              Instagram
-            </a>
-            <a href="#" className="text-sage/80 hover:text-cream transition-colors">
-              Twitter
-            </a>
-            <a href="#" className="text-sage/80 hover:text-cream transition-colors">
-              Facebook
-            </a>
-            <a href="#" className="text-sage/80 hover:text-cream transition-colors">
-              YouTube
-            </a>
-          </div>
-
-          {/* Copyright */}
-          <div className="pt-4 border-t border-moss/30 text-sm text-sage/70">
-            <p>© {currentYear} K.NOMAD. All rights reserved.</p>
-          </div>
-        </div>
+        {/* Copyright */}
+        <p className="text-sm text-sage/70">© {currentYear} K.NOMAD. All rights reserved.</p>
       </div>
     </footer>
   )

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -71,7 +71,7 @@ export function HeroSection({
         </div>
 
         {/* Filter Section */}
-        <div className="max-w-4xl mx-auto space-y-4">
+        <div className="max-w-7xl mx-auto space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {/* Budget Filter */}
             <div className="space-y-2">
@@ -125,7 +125,7 @@ export function HeroSection({
 
             {/* Season Filter */}
             <div className="space-y-2">
-              <label className="text-sm font-medium text-earth/80">최고 계절</label>
+              <label className="text-sm font-medium text-earth/80">계절</label>
               <select
                 value={selectedSeason}
                 onChange={(e) => onSeasonChange(e.target.value as Season | '')}


### PR DESCRIPTION
## Summary

- **HeroSection**: 필터 컨테이너 `max-w-4xl` → `max-w-7xl` 변경으로 화면 너비 최대 활용
- **HeroSection**: `최고 계절` 라벨을 `계절`로 간결하게 수정
- **Footer**: `footerSections` 배열 및 소셜 링크 등 미구현 `href="#"` 링크 13개 전부 제거, 브랜드 + 저작권만 유지

## Test plan

- [ ] 데스크탑(1920px)에서 필터 4개 너비 균등 확인
- [ ] 모바일(375px)에서 레이아웃 정상 확인
- [ ] Footer에 `href="#"` 링크 0개 확인
- [ ] `npx tsc --noEmit` 에러 0개
- [ ] `npm run build` 성공

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)