### PR TITLE
feat: 랜딩 화면 문구 변경 및 도시 수 DB 연동

### DIFF
--- a/__tests__/components/sections/HeroSection.test.tsx
+++ b/__tests__/components/sections/HeroSection.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HeroSection } from '@/components/sections/HeroSection'
+import type { BudgetRange, Region, Environment, Season } from '@/types'
+
+const defaultProps = {
+  selectedBudget: '' as BudgetRange | '',
+  selectedRegion: '전체' as Region | '전체' | '',
+  selectedEnvironment: '' as Environment | '',
+  selectedSeason: '' as Season | '',
+  onBudgetChange: vi.fn(),
+  onRegionChange: vi.fn(),
+  onEnvironmentChange: vi.fn(),
+  onSeasonChange: vi.fn(),
+  cityCount: 10,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('HeroSection - hasActiveFilters 로직', () => {
+  it('모든 필터 기본값 → 초기화 버튼 미표시', () => {
+    render(<HeroSection {...defaultProps} />)
+    expect(screen.queryByText('필터 초기화')).not.toBeInTheDocument()
+  })
+
+  it('budget 선택 시 초기화 버튼 표시', () => {
+    render(<HeroSection {...defaultProps} selectedBudget="under100" />)
+    expect(screen.getByText('필터 초기화')).toBeInTheDocument()
+  })
+
+  it('region이 "전체"가 아닌 값 → 초기화 버튼 표시', () => {
+    render(<HeroSection {...defaultProps} selectedRegion="제주도" />)
+    expect(screen.getByText('필터 초기화')).toBeInTheDocument()
+  })
+
+  it('environment 선택 시 초기화 버튼 표시', () => {
+    render(<HeroSection {...defaultProps} selectedEnvironment="자연친화" />)
+    expect(screen.getByText('필터 초기화')).toBeInTheDocument()
+  })
+
+  it('season 선택 시 초기화 버튼 표시', () => {
+    render(<HeroSection {...defaultProps} selectedSeason="봄" />)
+    expect(screen.getByText('필터 초기화')).toBeInTheDocument()
+  })
+})
+
+describe('HeroSection - handleReset', () => {
+  it('초기화 버튼 클릭 → onBudgetChange("") 호출', async () => {
+    const onBudgetChange = vi.fn()
+    render(<HeroSection {...defaultProps} selectedBudget="under100" onBudgetChange={onBudgetChange} />)
+    await userEvent.click(screen.getByText('필터 초기화'))
+    expect(onBudgetChange).toHaveBeenCalledWith('')
+  })
+
+  it('초기화 버튼 클릭 → onRegionChange("전체") 호출', async () => {
+    const onRegionChange = vi.fn()
+    render(<HeroSection {...defaultProps} selectedRegion="제주도" onRegionChange={onRegionChange} />)
+    await userEvent.click(screen.getByText('필터 초기화'))
+    expect(onRegionChange).toHaveBeenCalledWith('전체')
+  })
+
+  it('초기화 버튼 클릭 → onEnvironmentChange("") 호출', async () => {
+    const onEnvironmentChange = vi.fn()
+    render(<HeroSection {...defaultProps} selectedEnvironment="자연친화" onEnvironmentChange={onEnvironmentChange} />)
+    await userEvent.click(screen.getByText('필터 초기화'))
+    expect(onEnvironmentChange).toHaveBeenCalledWith('')
+  })
+
+  it('초기화 버튼 클릭 → onSeasonChange("") 호출', async () => {
+    const onSeasonChange = vi.fn()
+    render(<HeroSection {...defaultProps} selectedSeason="봄" onSeasonChange={onSeasonChange} />)
+    await userEvent.click(screen.getByText('필터 초기화'))
+    expect(onSeasonChange).toHaveBeenCalledWith('')
+  })
+})
+
+describe('HeroSection - 필터 select onChange', () => {
+  // HeroSection의 select 순서: 예산(0), 지역(1), 환경(2), 계절(3)
+  it('예산 select 변경 → onBudgetChange가 선택된 값으로 호출', async () => {
+    const onBudgetChange = vi.fn()
+    render(<HeroSection {...defaultProps} onBudgetChange={onBudgetChange} />)
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[0], 'under100')
+    expect(onBudgetChange).toHaveBeenCalledWith('under100')
+  })
+
+  it('지역 select 변경 → onRegionChange가 선택된 값으로 호출', async () => {
+    const onRegionChange = vi.fn()
+    render(<HeroSection {...defaultProps} onRegionChange={onRegionChange} />)
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[1], '제주도')
+    expect(onRegionChange).toHaveBeenCalledWith('제주도')
+  })
+
+  it('환경 select 변경 → onEnvironmentChange가 선택된 값으로 호출', async () => {
+    const onEnvironmentChange = vi.fn()
+    render(<HeroSection {...defaultProps} onEnvironmentChange={onEnvironmentChange} />)
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[2], '자연친화')
+    expect(onEnvironmentChange).toHaveBeenCalledWith('자연친화')
+  })
+
+  it('계절 select 변경 → onSeasonChange가 선택된 값으로 호출', async () => {
+    const onSeasonChange = vi.fn()
+    render(<HeroSection {...defaultProps} onSeasonChange={onSeasonChange} />)
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[3], '봄')
+    expect(onSeasonChange).toHaveBeenCalledWith('봄')
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
 import { HomeClient } from '@/components/HomeClient'
-import { getCities } from '@/lib/supabase/queries'
+import { getCities, getCityCount } from '@/lib/supabase/queries'
 
 export default async function Home() {
-  const cities = await getCities()
+  const [cities, cityCount] = await Promise.all([getCities(), getCityCount()])
 
-  return <HomeClient cities={cities} />
+  return <HomeClient cities={cities} cityCount={cityCount} />
 }

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -8,9 +8,10 @@ import type { BudgetRange, Region, Environment, Season, City } from '@/types'
 
 interface HomeClientProps {
   cities: City[]
+  cityCount: number
 }
 
-export function HomeClient({ cities }: HomeClientProps) {
+export function HomeClient({ cities, cityCount }: HomeClientProps) {
   const [selectedBudget, setSelectedBudget] = useState<BudgetRange | ''>('')
   const [selectedRegion, setSelectedRegion] = useState<Region | '전체' | ''>('전체')
   const [selectedEnvironment, setSelectedEnvironment] = useState<Environment | ''>('')
@@ -27,6 +28,7 @@ export function HomeClient({ cities }: HomeClientProps) {
         onRegionChange={setSelectedRegion}
         onEnvironmentChange={setSelectedEnvironment}
         onSeasonChange={setSelectedSeason}
+        cityCount={cityCount}
       />
       <CityListSection
         cities={cities}

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -15,6 +15,7 @@ interface HeroSectionProps {
   onRegionChange: (value: Region | '전체') => void
   onEnvironmentChange: (value: Environment | '') => void
   onSeasonChange: (value: Season | '') => void
+  cityCount: number
 }
 
 export function HeroSection({
@@ -26,6 +27,7 @@ export function HeroSection({
   onRegionChange,
   onEnvironmentChange,
   onSeasonChange,
+  cityCount,
 }: HeroSectionProps) {
   const handleReset = () => {
     onBudgetChange('')
@@ -46,10 +48,10 @@ export function HeroSection({
         {/* Headline */}
         <div className="text-center space-y-4">
           <h1 className="text-3xl lg:text-5xl font-bold text-earth">
-            대한민국에서 노마드로 살기 좋은 도시
+            한국에서 디지털 노마드로 살기 좋은 도시
           </h1>
           <p className="text-lg lg:text-xl text-earth/70">
-            10개 도시 | 실시간 데이터
+            총 {cityCount}개 도시 | 실시간 데이터
           </p>
         </div>
 

--- a/lib/supabase/queries.ts
+++ b/lib/supabase/queries.ts
@@ -44,6 +44,14 @@ export async function getCities(): Promise<City[]> {
   return (citiesData ?? []).map(row => mapCity(row, likesMap[row.id] ?? 0, dislikesMap[row.id] ?? 0))
 }
 
+export async function getCityCount(): Promise<number> {
+  const supabase = await createClient()
+  const { count } = await supabase
+    .from('cities')
+    .select('*', { count: 'exact', head: true })
+  return count ?? 0
+}
+
 export async function getCityById(id: string): Promise<City | null> {
   const supabase = await createClient()
 


### PR DESCRIPTION
## Summary

- HeroSection 헤드라인을 `"한국에서 디지털 노마드로 살기 좋은 도시"`로 변경
- `getCityCount()` 쿼리 함수 추가 (`lib/supabase/queries.ts`)
- 도시 수를 Supabase DB에서 동적으로 fetch하여 `총 N개 도시` 형식으로 표시
- `getCities`와 `getCityCount`를 `Promise.all`로 병렬 요청 처리
- `HeroSection.test.tsx` — `cityCount` prop 추가 반영

Closes #7

## Test plan

- [ ] 개발 서버 실행 후 HeroSection 헤드라인 문구 확인
- [ ] "총 N개 도시" 표시가 DB 실제 count와 일치하는지 확인
- [ ] `npx tsc --noEmit` — 에러 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)