### PR TITLE
fix: HeroSection 헤드라인 문구 변경 (fixes #9)

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -48,7 +48,7 @@ export function HeroSection({
         {/* Headline */}
         <div className="text-center space-y-4">
           <h1 className="text-3xl lg:text-5xl font-bold text-earth">
-            한국에서 디지털 노마드로 살기 좋은 도시
+            한국무역협회 KITA.net
           </h1>
           <p className="text-lg lg:text-xl text-earth/70">
             총 {cityCount}개 도시 | 실시간 데이터


### PR DESCRIPTION
## Summary

- HeroSection 헤드라인 문구 수정
- `한국에서 디지털 노마드로 살기 좋은 도시` → `한국무역협회 KITA.net`
- 파일: `components/sections/HeroSection.tsx` line 51

Closes #9

## Test plan

- [ ] 메인 페이지(`/`) 접속 후 헤드라인 문구 확인
- [ ] 모바일/태블릿/데스크톱 레이아웃 이상 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)